### PR TITLE
docs: fix caas-image-repo post-bootstrap changeability

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -246,6 +246,8 @@ const (
 
 	// CAASImageRepo sets the docker repo to use
 	// for the jujud operator and mongo images.
+	// Note: the repository itself is read-only after bootstrap; only
+	// authentication credentials (for a private registry) can be updated.
 	CAASImageRepo = "caas-image-repo"
 
 	// Features allows a list of runtime changeable features to be updated.

--- a/docs/reference/configuration/list-of-controller-configuration-keys.md
+++ b/docs/reference/configuration/list-of-controller-configuration-keys.md
@@ -223,6 +223,8 @@ testing is
 
 `caas-image-repo` sets the docker repo to use
 for the jujud operator and mongo images.
+Note: the repository itself is read-only after bootstrap; only
+authentication credentials (for a private registry) can be updated.
 
 **Type:** string
 


### PR DESCRIPTION
Fixes #20089.

`caas-image-repo` is documented as fully mutable post-bootstrap, but the repository itself is read-only -- only authentication credentials for a private registry can be updated. This PR adds that clarification to the constant's doc comment in `config.go` and includes the regenerated reference doc.